### PR TITLE
[Back- Fix]     : "위시리스트 기반 추천 vod_score heavy_score만 사용"

### DIFF
--- a/recommends/views.py
+++ b/recommends/views.py
@@ -528,7 +528,7 @@ class wishlist_recommend(APIView): # <9>
 		# vod list 가져오기
 		query_set = Vod.objects.all()
 		vod_list=read_frame(query_set)
-		score_query_set=vod_score.objects.all()
+		score_query_set=vod_score.objects.filter(method=1)
 		score=read_frame(score_query_set)
 		
 		vod = pd.DataFrame([[1]*len(vod_id_list), vod_id_list, [0.7]*len(vod_id_list)]).T


### PR DESCRIPTION
### 📝 Description

- 위시리스트 기반 추천에 heavy_score만 사용하도록 변경

### 💽 Commits

- 위시리스트 기반 추천에 heavy_score만 사용하도록 변경

### 🖼 Result

```
# vod list 가져오기
		query_set = Vod.objects.all()
		vod_list=read_frame(query_set)
		score_query_set=vod_score.objects.filter(method=1)
		score=read_frame(score_query_set)
```
		
